### PR TITLE
Additions to supply `changedProperties` in `ReactiveElement` update lifecycle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lit-svelte-stores",
-  "version": "0.2.3",
+  "version": "0.2.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "lit-svelte-stores",
-      "version": "0.2.3",
+      "version": "0.2.5",
       "license": "ISC",
       "dependencies": {
         "@lit-labs/task": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "module": "dist/index.js",
   "type": "module",
   "scripts": {
+    "prepare": "npm run build",
     "build": "tsc",
     "build-watch": "tsc -w",
     "start": "npm run build && concurrently -k \"npm run build-watch\" \"wds --config demo/web-dev-server.config.mjs\""

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lit-svelte-stores",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Lit controllers to use svelte stores to manage state",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/src/store-subscriber.ts
+++ b/src/store-subscriber.ts
@@ -35,7 +35,7 @@ export class StoreSubscriber<V> implements ReactiveController {
         this._unsubscribe = store.subscribe((value) => {
           const prevValue = this.value
           this.value = value;
-          this.notify({ [this.notifyPropertyName || 'value']: this.notifyPropertyName ? { value: prevValue } : prevValue });
+          this.notify(this.notifyPropertyName || 'value', this.notifyPropertyName ? { value: prevValue } : prevValue);
         });
       }
       this._previousStore = store;
@@ -71,10 +71,9 @@ export class StoreSubscriber<V> implements ReactiveController {
     return this.getStore();
   }
 
-  protected notify(properties?: Record<string, unknown>): void {
-    if (properties && this.host.requestUpdate.length > 0) {
-      for (const [key, value] of Object.entries(properties))
-        (this.host as ReactiveElement).requestUpdate(key, value);
+  protected notify(key: string, value: unknown): void {
+    if (this.host.requestUpdate.length > 0) {
+      (this.host as ReactiveElement).requestUpdate(key, value);
     } else {
       this.host.requestUpdate();
     }

--- a/src/store-subscriber.ts
+++ b/src/store-subscriber.ts
@@ -20,7 +20,7 @@ export class StoreSubscriber<V> implements ReactiveController {
     protected host: ReactiveControllerHost,
     protected getStore: () => Readable<V> | undefined,
     protected resubscribeIfChanged?: () => Array<any>,
-    protected notifyPropertyName: string = 'value'
+    protected notifyPropertyName?: string
   ) {
     host.addController(this);
   }
@@ -33,8 +33,9 @@ export class StoreSubscriber<V> implements ReactiveController {
 
       if (store) {
         this._unsubscribe = store.subscribe((value) => {
+          const prevValue = this.value
           this.value = value;
-          this.notify({ [this.notifyPropertyName]: this._previousStore ? get(this._previousStore) : null });
+          this.notify({ [this.notifyPropertyName || 'value']: this.notifyPropertyName ? { value: prevValue } : prevValue });
         });
       }
       this._previousStore = store;

--- a/src/store-subscriber.ts
+++ b/src/store-subscriber.ts
@@ -19,7 +19,8 @@ export class StoreSubscriber<V> implements ReactiveController {
   constructor(
     protected host: ReactiveControllerHost,
     protected getStore: () => Readable<V> | undefined,
-    protected resubscribeIfChanged?: () => Array<any>
+    protected resubscribeIfChanged?: () => Array<any>,
+    protected notifyPropertyName: string = 'value'
   ) {
     host.addController(this);
   }
@@ -33,7 +34,7 @@ export class StoreSubscriber<V> implements ReactiveController {
       if (store) {
         this._unsubscribe = store.subscribe((value) => {
           this.value = value;
-          this.notify({ value });
+          this.notify({ [this.notifyPropertyName]: this._previousStore ? get(this._previousStore) : null });
         });
       }
       this._previousStore = store;

--- a/src/store-subscriber.ts
+++ b/src/store-subscriber.ts
@@ -1,5 +1,5 @@
 import { Readable, Unsubscriber, get } from "svelte/store";
-import { ReactiveController, ReactiveControllerHost } from "lit";
+import { ReactiveController, ReactiveControllerHost, ReactiveElement } from "lit";
 import isEqual from "lodash-es/isEqual.js";
 
 /**
@@ -33,7 +33,7 @@ export class StoreSubscriber<V> implements ReactiveController {
       if (store) {
         this._unsubscribe = store.subscribe((value) => {
           this.value = value;
-          this.host.requestUpdate();
+          this.notify({ value });
         });
       }
       this._previousStore = store;
@@ -67,5 +67,14 @@ export class StoreSubscriber<V> implements ReactiveController {
 
   store() {
     return this.getStore();
+  }
+
+  protected notify(properties?: Record<string, unknown>): void {
+    if (properties && this.host.requestUpdate.length > 0) {
+      for (const [key, value] of Object.entries(properties))
+        (this.host as ReactiveElement).requestUpdate(key, value);
+    } else {
+      this.host.requestUpdate();
+    }
   }
 }


### PR DESCRIPTION
This achieves two main things:

1. `host.requestUpdate` is now provided with data of the change. The key in the provided `changedProperties` is `'value'` by default; similarly to the pattern used in other common `ReactiveController` implementations. In this mode the inner `value` attribute of the `StoreSubscriber` will be sent *directly as the value*.
2. The key set in `changedProperties` can be overridden with `notifyPropertyName`, which allows multiple `StoreSubscribers` to be bound to the same `ReactiveElement` and differentiated in `updated` etc lifecycle hooks. In this mode the  inner `value` attribute of the `StoreSubscriber` will be sent *as a `value` sub-property of the returned (otherwise empty) object*. In this way, `changedProperties.get(notifyPropertyName).value` can be compared directly with `this[notifyPropertyName].value` in update lifecycle equality checks.

To finalise I thought you might want to start combining these trailing parameters into an `options` object?